### PR TITLE
Infinite files click event handler loop in Edge

### DIFF
--- a/file-drop-zone.html
+++ b/file-drop-zone.html
@@ -226,7 +226,9 @@ class FileDropZone extends Polymer.GestureEventListeners(Polymer.Element) {
     this.addEventListener('dragover', e => this._onDragEvent(e));
     this.addEventListener('dragleave', e => this._onDragEvent(e));
     this.addEventListener('drop', e => this._onFileDrop(e));
-    Polymer.Gestures.addListener(this, 'tap', e => this.$.files.click());
+    Polymer.Gestures.addListener(this, 'tap', e => {
+      this.$.files.dispatchEvent(new MouseEvent("click", { bubbles: false }));
+    });
   }
 
   _onchangeChanged(cb) {


### PR DESCRIPTION
Making files click event non bubbling fixes infinite recursion of event handlers calls in Edge.